### PR TITLE
refactor: use static fs access import

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -1,3 +1,4 @@
+import { access } from 'fs/promises';
 import dayjs from 'dayjs';
 import ko from 'dayjs/locale/ko.js';
 dayjs.locale(ko);
@@ -217,8 +218,7 @@ class FileNameGenerator {
    */
   static async checkFileExists(filePath) {
     try {
-      const fs = await import('fs/promises');
-      await fs.access(filePath);
+      await access(filePath);
       return true; // 파일이 존재함
     } catch {
       return false; // 파일이 존재하지 않음


### PR DESCRIPTION
## Summary
- add static `access` import from `fs/promises`
- replace dynamic fs import in `checkFileExists`

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install vitest` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68ae584748e08325a801ae579ea6e73e