### PR TITLE
Use strict Day.js parsing for Korean dates

### DIFF
--- a/core/utils.js
+++ b/core/utils.js
@@ -26,22 +26,18 @@ class DateFormatter {
   }
 
   /**
-   * 한국 형식을 ISO 형식으로 변환
-   * @param {string} koreanDate - YY.MM.DD(요일) 형식
-   * @returns {string} ISO 형식 (YYYY-MM-DD)
+   * 한국 형식(YY.MM.DD)을 ISO 형식으로 변환
+   * @param {string} koreanDate - YY.MM.DD 형식 (예: '24.05.01')
+   * @returns {string} ISO 형식 (YYYY-MM-DD). 유효하지 않으면 빈 문자열 반환
    */
   static fromKoreanFormat(koreanDate) {
     if (!koreanDate) return '';
-    
+
     try {
-      // YY.MM.DD 형식에서 YYYY-MM-DD로 변환
-      const match = koreanDate.match(/^(\d{2})\.(\d{2})\.(\d{2})/);
-      if (!match) return '';
-      
-      const [, year, month, day] = match;
-      const fullYear = parseInt(year) < 50 ? `20${year}` : `19${year}`;
-      
-      return `${fullYear}-${month}-${day}`;
+      const dayjsDate = dayjs(koreanDate, 'YY.MM.DD', true);
+      if (!dayjsDate.isValid()) return '';
+
+      return dayjsDate.format('YYYY-MM-DD');
     } catch (error) {
       console.error('한국 날짜 형식 변환 오류:', error);
       return '';

--- a/test/dateFormatter.test.js
+++ b/test/dateFormatter.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { DateFormatter } from '../core/utils.js';
+
+describe('DateFormatter.fromKoreanFormat', () => {
+  it('converts valid date', () => {
+    expect(DateFormatter.fromKoreanFormat('24.05.01')).toBe('2024-05-01');
+  });
+
+  it('returns empty string for invalid date', () => {
+    expect(DateFormatter.fromKoreanFormat('24.13.01')).toBe('');
+  });
+
+  it('returns empty string for wrong format', () => {
+    expect(DateFormatter.fromKoreanFormat('24.05.01(수)')).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- refactor `DateFormatter.fromKoreanFormat` to parse `YY.MM.DD` using Day.js strict mode
- return empty string for invalid or mismatched date strings
- add tests covering valid, invalid, and malformed Korean date inputs

## Testing
- `npm install --no-save vitest dayjs` *(fails: 403 Forbidden)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae584855d083259b83a6e9852eebbd